### PR TITLE
fix(gnb): don't crash on an N3 read error or short GTP packet

### DIFF
--- a/gnb/gtp.go
+++ b/gnb/gtp.go
@@ -103,7 +103,14 @@ func receiveGtpPacketFromN3Conn(ctx context.Context, n3Conn *net.UDPConn, ranDat
 			if errors.Is(err, net.ErrClosed) {
 				return
 			}
+			// e.g. an ICMP port-unreachable surfaced on the connected
+			// socket; there is no packet to process.
 			gnbLogger.GtpLog.Warnf("Error reading GTP packet from N3 connection: %v", err)
+			continue
+		}
+		if n < 8 {
+			gnbLogger.GtpLog.Warnf("Short GTP packet (%d bytes) from N3 connection, dropping", n)
+			continue
 		}
 		gnbLogger.GtpLog.Tracef("Received %d bytes of GTP packet from N3 connection: %+v", n, buffer[:n])
 		gnbLogger.GtpLog.Tracef("Received %d bytes of GTP packet from N3 connection", n)


### PR DESCRIPTION
## What happened

`receiveGtpPacketFromN3Conn` logs a read error but then falls through with `n = 0`, so `parseGtpPacket` slices `gtpPacket[:8]` on an empty buffer and the gNB dies with an index-out-of-range panic:

```
panic: runtime error: slice bounds out of range [:8] with capacity 0
  gnb.parseGtpPacket  gnb/gtp.go:184
  gnb.forwardPacketToUe  gnb/gtp.go:137
  gnb.receiveGtpPacketFromN3Conn  gnb/gtp.go:113
```

Because the N3 socket is a *connected* UDP socket (`net.DialUDP`, `gnb/gnb.go`), the kernel surfaces an ICMP port-unreachable from the UPF as exactly such a read error. So a single uplink packet the UPF cannot yet handle — e.g. while its PDRs are still being installed, or any transient at the peer — kills the whole gNB. We hit this reproducibly while testing free-ran-ue against a replacement UPF ([zebra-rs](https://github.com/zebra-rs/zebra-rs)/[cradle-rs](https://github.com/cradle-rs/cradle-rs) — zebra-rs/zebra-rs#1930): the first uplink G-PDU sent before the PDR landed bounced as ICMP unreachable and the gNB process panicked.

## The fix

- `continue` the receive loop on a read error (there is no packet to process); `net.ErrClosed` still returns as before.
- Drop datagrams shorter than the 8-byte GTP-U header instead of parsing them.

With this patch the same scenario just logs the existing warning and the gNB keeps running; once the UPF's PDR is in place, uplink traffic flows and end-to-end UE ping works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)